### PR TITLE
reverts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,8 @@ name = "sunscreen_curve25519"
 # - update html_root_url
 # - update README if required by semver
 version = "0.8.1"
-authors = [
-    "Isis Lovecruft <isis@patternsinthevoid.net>",
-    "Henry de Valence <hdevalence@hdevalence.ca>",
-]
+authors = ["Isis Lovecruft <isis@patternsinthevoid.net>",
+           "Henry de Valence <hdevalence@hdevalence.ca>"]
 readme = "README.md"
 license = "BSD-3-Clause"
 repository = "https://github.com/zkcrypto/curve25519-dalek-ng"
@@ -16,7 +14,11 @@ documentation = "https://docs.rs/curve25519-dalek-ng"
 categories = ["cryptography", "no-std"]
 keywords = ["cryptography", "crypto", "ristretto", "curve25519", "ristretto255"]
 description = "A pure-Rust implementation of group operations on ristretto255 and Curve25519"
-exclude = ["**/.gitignore", ".gitignore", ".travis.yml"]
+exclude = [
+    "**/.gitignore",
+    ".gitignore",
+    ".travis.yml",
+]
 
 [package.metadata.docs.rs]
 # Disabled for now since this is borked; tracking https://github.com/rust-lang/docs.rs/issues/302
@@ -35,19 +37,13 @@ harness = false
 
 [dependencies]
 rand_core = { version = "0.6", default-features = false }
-byteorder = { version = "^1.2.3", default-features = false, features = [
-    "i128",
-] }
+byteorder = { version = "^1.2.3", default-features = false, features = ["i128"] }
 digest = { version = "0.9", default-features = false }
 subtle = { package = "subtle-ng", version = "2.5", default-features = false }
-serde = { version = "1.0", default-features = false, optional = true, features = [
-    "derive",
-] }
+serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 # The original packed_simd package was orphaned, see
 # https://github.com/rust-lang/packed_simd/issues/303#issuecomment-701361161
-packed_simd = { version = "0.3.4", package = "packed_simd_2", features = [
-    "into_bits",
-], optional = true }
+packed_simd = { version = "0.3.4", package = "packed_simd_2", features = ["into_bits"], optional = true }
 zeroize = { version = "1", default-features = false }
 
 [features]

--- a/benches/dalek_benchmarks.rs
+++ b/benches/dalek_benchmarks.rs
@@ -1,4 +1,7 @@
 #![allow(non_snake_case)]
+
+// sunscreen allowances
+#![rustfmt::skip]
 #![allow(deprecated, unused, clippy::all)]
 
 extern crate rand;

--- a/benches/dalek_benchmarks.rs
+++ b/benches/dalek_benchmarks.rs
@@ -146,14 +146,14 @@ mod multiscalar_benches {
                 let static_size = total_size;
 
                 let static_points = construct_points(static_size);
-                let precomp = VartimeEdwardsPrecomputation::new(static_points);
+                let precomp = VartimeEdwardsPrecomputation::new(&static_points);
                 // Rerandomize the scalars for every call to prevent
                 // false timings from better caching (e.g., the CPU
                 // cache lifts exactly the right table entries for the
                 // benchmark into the highest cache levels).
                 b.iter_batched(
                     || construct_scalars(static_size),
-                    |scalars| precomp.vartime_multiscalar_mul(scalars),
+                    |scalars| precomp.vartime_multiscalar_mul(&scalars),
                     BatchSize::SmallInput,
                 );
             },
@@ -174,7 +174,7 @@ mod multiscalar_benches {
 
                 let static_points = construct_points(static_size);
                 let dynamic_points = construct_points(dynamic_size);
-                let precomp = VartimeEdwardsPrecomputation::new(static_points);
+                let precomp = VartimeEdwardsPrecomputation::new(&static_points);
                 // Rerandomize the scalars for every call to prevent
                 // false timings from better caching (e.g., the CPU
                 // cache lifts exactly the right table entries for the

--- a/benches/dalek_benchmarks.rs
+++ b/benches/dalek_benchmarks.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 
 // sunscreen allowances
-#![rustfmt::skip]
+#![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(deprecated, unused, clippy::all)]
 
 extern crate rand;

--- a/benches/dalek_benchmarks.rs
+++ b/benches/dalek_benchmarks.rs
@@ -1,6 +1,5 @@
 #![allow(non_snake_case)]
-#![allow(deprecated)]
-#![allow(clippy::all)]
+#![allow(deprecated, unused, clippy::all)]
 
 extern crate rand;
 use rand::rngs::OsRng;
@@ -99,7 +98,6 @@ mod multiscalar_benches {
             .collect()
     }
 
-    #[allow(unused)]
     fn construct(n: usize) -> (Vec<Scalar>, Vec<EdwardsPoint>) {
         (construct_scalars(n), construct_points(n))
     }

--- a/benches/dalek_benchmarks.rs
+++ b/benches/dalek_benchmarks.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case)]
 #![allow(deprecated)]
+#![allow(clippy::all)]
 
 extern crate rand;
 use rand::rngs::OsRng;

--- a/src/backend/serial/scalar_mul/variable_base.rs
+++ b/src/backend/serial/scalar_mul/variable_base.rs
@@ -3,7 +3,7 @@
 use traits::Identity;
 use scalar::Scalar;
 use edwards::EdwardsPoint;
-use backend::serial::curve_models::{ProjectiveNielsPoint};
+use backend::serial::curve_models::{ProjectiveNielsPoint, ProjectivePoint};
 use window::LookupTable;
 
 /// Perform constant-time, variable-base scalar multiplication.

--- a/src/field.rs
+++ b/src/field.rs
@@ -33,7 +33,8 @@ use subtle::ConstantTimeEq;
 use constants;
 use backend;
 
-
+#[cfg(feature = "u64_backend")]
+pub use backend::serial::u64::field::*;
 /// A `FieldElement` represents an element of the field
 /// \\( \mathbb Z / (2\^{255} - 19)\\).
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ extern crate serde;
 
 // Internal macros. Must come first!
 #[macro_use]
+#[rustfmt::skip]
 pub(crate) mod macros;
 
 //------------------------------------------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 // - Henry de Valence <hdevalence@hdevalence.ca>
 
 // sunscreen allowances
+#![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(clippy::all)]
 #![allow(rustdoc::broken_intra_doc_links)]
 #![allow(unused_imports, noop_method_call)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@
 // - Henry de Valence <hdevalence@hdevalence.ca>
 #![allow(rustdoc::broken_intra_doc_links)]
 #![allow(clippy::all)]
+#![allow(unused_imports)]
+#![allow(noop_method_call)]
 #![no_std]
 #![cfg_attr(feature = "simd_backend", feature(stdsimd))]
 #![cfg_attr(feature = "nightly", feature(doc_cfg))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,12 @@
 // Authors:
 // - Isis Agora Lovecruft <isis@patternsinthevoid.net>
 // - Henry de Valence <hdevalence@hdevalence.ca>
-#![allow(rustdoc::broken_intra_doc_links)]
+
+// sunscreen allowances
 #![allow(clippy::all)]
-#![allow(unused_imports)]
-#![allow(noop_method_call)]
+#![allow(rustdoc::broken_intra_doc_links)]
+#![allow(unused_imports, noop_method_call)]
+
 #![no_std]
 #![cfg_attr(feature = "simd_backend", feature(stdsimd))]
 #![cfg_attr(feature = "nightly", feature(doc_cfg))]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -33,7 +33,7 @@ macro_rules! define_add_variants {
                 &self + &rhs
             }
         }
-    };
+    }
 }
 
 /// Define non-borrow variants of `AddAssign`.
@@ -44,7 +44,7 @@ macro_rules! define_add_assign_variants {
                 *self += &rhs;
             }
         }
-    };
+    }
 }
 
 /// Define borrow and non-borrow variants of `Sub`.
@@ -70,7 +70,7 @@ macro_rules! define_sub_variants {
                 &self - &rhs
             }
         }
-    };
+    }
 }
 
 /// Define non-borrow variants of `SubAssign`.
@@ -81,7 +81,7 @@ macro_rules! define_sub_assign_variants {
                 *self -= &rhs;
             }
         }
-    };
+    }
 }
 
 /// Define borrow and non-borrow variants of `Mul`.
@@ -107,7 +107,7 @@ macro_rules! define_mul_variants {
                 &self * &rhs
             }
         }
-    };
+    }
 }
 
 /// Define non-borrow variants of `MulAssign`.
@@ -118,5 +118,6 @@ macro_rules! define_mul_assign_variants {
                 *self *= &rhs;
             }
         }
-    };
+    }
 }
+

--- a/src/ristretto.rs
+++ b/src/ristretto.rs
@@ -173,8 +173,8 @@ use constants;
 use field::FieldElement;
 
 use subtle::Choice;
-use subtle::ConditionallyNegatable;
 use subtle::ConditionallySelectable;
+use subtle::ConditionallyNegatable;
 use subtle::ConstantTimeEq;
 
 use edwards::EdwardsBasepointTable;
@@ -262,7 +262,8 @@ impl CompressedRistretto {
 
         let s = FieldElement::from_bytes(self.as_bytes());
         let s_bytes_check = s.to_bytes();
-        let s_encoding_is_canonical = &s_bytes_check[..].ct_eq(self.as_bytes());
+        let s_encoding_is_canonical =
+            &s_bytes_check[..].ct_eq(self.as_bytes());
         let s_is_negative = s.is_negative();
 
         if s_encoding_is_canonical.unwrap_u8() == 0u8 || s_is_negative.unwrap_u8() == 1u8 {
@@ -272,8 +273,8 @@ impl CompressedRistretto {
         // Step 2.  Compute (X:Y:Z:T).
         let one = FieldElement::one();
         let ss = s.square();
-        let u1 = &one - &ss; //  1 + as²
-        let u2 = &one + &ss; //  1 - as²    where a=-1
+        let u1 = &one - &ss;      //  1 + as²
+        let u2 = &one + &ss;      //  1 - as²    where a=-1
         let u2_sqr = u2.square(); // (1 - as²)²
 
         // v == ad(1+as²)² - (1-as²)²            where d=-121665/121666
@@ -281,7 +282,7 @@ impl CompressedRistretto {
 
         let (ok, I) = (&v * &u2_sqr).invsqrt(); // 1/sqrt(v*u_2²)
 
-        let Dx = &I * &u2; // 1/sqrt(v)
+        let Dx = &I * &u2;         // 1/sqrt(v)
         let Dy = &I * &(&Dx * &v); // 1/u2
 
         // x == | 2s/sqrt(v) | == + sqrt(4s²/(ad(1+as²)² - (1-as²)²))
@@ -295,18 +296,10 @@ impl CompressedRistretto {
         // t == ((1+as²) sqrt(4s²/(ad(1+as²)² - (1-as²)²)))/(1-as²)
         let t = &x * &y;
 
-        if ok.unwrap_u8() == 0u8
-            || t.is_negative().unwrap_u8() == 1u8
-            || y.is_zero().unwrap_u8() == 1u8
-        {
+        if ok.unwrap_u8() == 0u8 || t.is_negative().unwrap_u8() == 1u8 || y.is_zero().unwrap_u8() == 1u8 {
             None
         } else {
-            Some(RistrettoPoint(EdwardsPoint {
-                X: x,
-                Y: y,
-                Z: one,
-                T: t,
-            }))
+            Some(RistrettoPoint(EdwardsPoint{X: x, Y: y, Z: one, T: t}))
         }
     }
 }
@@ -332,15 +325,14 @@ impl Default for CompressedRistretto {
 // serializers to serialize those structures.
 
 #[cfg(feature = "serde")]
-use serde::de::Visitor;
+use serde::{self, Serialize, Deserialize, Serializer, Deserializer};
 #[cfg(feature = "serde")]
-use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
+use serde::de::Visitor;
 
 #[cfg(feature = "serde")]
 impl Serialize for RistrettoPoint {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
+        where S: Serializer
     {
         use serde::ser::SerializeTuple;
         let mut tup = serializer.serialize_tuple(32)?;
@@ -354,8 +346,7 @@ impl Serialize for RistrettoPoint {
 #[cfg(feature = "serde")]
 impl Serialize for CompressedRistretto {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
+        where S: Serializer
     {
         use serde::ser::SerializeTuple;
         let mut tup = serializer.serialize_tuple(32)?;
@@ -369,8 +360,7 @@ impl Serialize for CompressedRistretto {
 #[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for RistrettoPoint {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
+        where D: Deserializer<'de>
     {
         struct RistrettoPointVisitor;
 
@@ -382,13 +372,11 @@ impl<'de> Deserialize<'de> for RistrettoPoint {
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<RistrettoPoint, A::Error>
-            where
-                A: serde::de::SeqAccess<'de>,
+                where A: serde::de::SeqAccess<'de>
             {
                 let mut bytes = [0u8; 32];
                 for i in 0..32 {
-                    bytes[i] = seq
-                        .next_element()?
+                    bytes[i] = seq.next_element()?
                         .ok_or(serde::de::Error::invalid_length(i, &"expected 32 bytes"))?;
                 }
                 CompressedRistretto(bytes)
@@ -404,8 +392,7 @@ impl<'de> Deserialize<'de> for RistrettoPoint {
 #[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for CompressedRistretto {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
+        where D: Deserializer<'de>
     {
         struct CompressedRistrettoVisitor;
 
@@ -417,13 +404,11 @@ impl<'de> Deserialize<'de> for CompressedRistretto {
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<CompressedRistretto, A::Error>
-            where
-                A: serde::de::SeqAccess<'de>,
+                where A: serde::de::SeqAccess<'de>
             {
                 let mut bytes = [0u8; 32];
                 for i in 0..32 {
-                    bytes[i] = seq
-                        .next_element()?
+                    bytes[i] = seq.next_element()?
                         .ok_or(serde::de::Error::invalid_length(i, &"expected 32 bytes"))?;
                 }
                 Ok(CompressedRistretto(bytes))
@@ -519,8 +504,7 @@ impl RistrettoPoint {
     /// ```
     #[cfg(feature = "alloc")]
     pub fn double_and_compress_batch<'a, I>(points: I) -> Vec<CompressedRistretto>
-    where
-        I: IntoIterator<Item = &'a RistrettoPoint>,
+        where I: IntoIterator<Item = &'a RistrettoPoint>
     {
         #[derive(Copy, Clone, Debug)]
         struct BatchCompressState {
@@ -546,69 +530,64 @@ impl RistrettoPoint {
                 let dTT = &P.0.T.square() * &constants::EDWARDS_D;
 
                 let e = &P.0.X * &(&P.0.Y + &P.0.Y); // = 2*X*Y
-                let f = &ZZ + &dTT; // = Z^2 + d*T^2
-                let g = &YY + &XX; // = Y^2 - a*X^2
-                let h = &ZZ - &dTT; // = Z^2 - d*T^2
+                let f = &ZZ + &dTT;                  // = Z^2 + d*T^2
+                let g = &YY + &XX;                   // = Y^2 - a*X^2
+                let h = &ZZ - &dTT;                  // = Z^2 - d*T^2
 
                 let eg = &e * &g;
                 let fh = &f * &h;
 
-                BatchCompressState { e, f, g, h, eg, fh }
+                BatchCompressState{ e, f, g, h, eg, fh }
             }
         }
 
-        let states: Vec<BatchCompressState> =
-            points.into_iter().map(BatchCompressState::from).collect();
+        let states: Vec<BatchCompressState> = points.into_iter().map(BatchCompressState::from).collect();
 
         let mut invs: Vec<FieldElement> = states.iter().map(|state| state.efgh()).collect();
 
         FieldElement::batch_invert(&mut invs[..]);
 
-        states
-            .iter()
-            .zip(invs.iter())
-            .map(|(state, inv): (&BatchCompressState, &FieldElement)| {
-                let Zinv = &state.eg * &inv;
-                let Tinv = &state.fh * &inv;
+        states.iter().zip(invs.iter()).map(|(state, inv): (&BatchCompressState, &FieldElement)| {
+            let Zinv = &state.eg * &inv;
+            let Tinv = &state.fh * &inv;
 
-                let mut magic = constants::INVSQRT_A_MINUS_D;
+            let mut magic = constants::INVSQRT_A_MINUS_D;
 
-                let negcheck1 = (&state.eg * &Zinv).is_negative();
+            let negcheck1 = (&state.eg * &Zinv).is_negative();
 
-                let mut e = state.e;
-                let mut g = state.g;
-                let mut h = state.h;
+            let mut e = state.e;
+            let mut g = state.g;
+            let mut h = state.h;
 
-                let minus_e = -&e;
-                let f_times_sqrta = &state.f * &constants::SQRT_M1;
+            let minus_e = -&e;
+            let f_times_sqrta = &state.f * &constants::SQRT_M1;
 
-                e.conditional_assign(&state.g, negcheck1);
-                g.conditional_assign(&minus_e, negcheck1);
-                h.conditional_assign(&f_times_sqrta, negcheck1);
+            e.conditional_assign(&state.g,       negcheck1);
+            g.conditional_assign(&minus_e,       negcheck1);
+            h.conditional_assign(&f_times_sqrta, negcheck1);
 
-                magic.conditional_assign(&constants::SQRT_M1, negcheck1);
+            magic.conditional_assign(&constants::SQRT_M1, negcheck1);
 
-                let negcheck2 = (&(&h * &e) * &Zinv).is_negative();
+            let negcheck2 = (&(&h * &e) * &Zinv).is_negative();
 
-                g.conditional_negate(negcheck2);
+            g.conditional_negate(negcheck2);
 
-                let mut s = &(&h - &g) * &(&magic * &(&g * &Tinv));
+            let mut s = &(&h - &g) * &(&magic * &(&g * &Tinv));
 
-                let s_is_negative = s.is_negative();
-                s.conditional_negate(s_is_negative);
+            let s_is_negative = s.is_negative();
+            s.conditional_negate(s_is_negative);
 
-                CompressedRistretto(s.to_bytes())
-            })
-            .collect()
+            CompressedRistretto(s.to_bytes())
+        }).collect()
     }
+
 
     /// Return the coset self + E[4], for debugging.
     fn coset4(&self) -> [EdwardsPoint; 4] {
-        [
-            self.0,
-            &self.0 + &constants::EIGHT_TORSION[2],
-            &self.0 + &constants::EIGHT_TORSION[4],
-            &self.0 + &constants::EIGHT_TORSION[6],
+        [  self.0
+        , &self.0 + &constants::EIGHT_TORSION[2]
+        , &self.0 + &constants::EIGHT_TORSION[4]
+        , &self.0 + &constants::EIGHT_TORSION[6]
         ]
     }
 
@@ -645,15 +624,12 @@ impl RistrettoPoint {
         use backend::serial::curve_models::CompletedPoint;
 
         // The conversion from W_i is exactly the conversion from P1xP1.
-        RistrettoPoint(
-            CompletedPoint {
-                X: &(&s + &s) * &D,
-                Z: &N_t * &constants::SQRT_AD_MINUS_ONE,
-                Y: &FieldElement::one() - &s_sq,
-                T: &FieldElement::one() + &s_sq,
-            }
-            .to_extended(),
-        )
+        RistrettoPoint(CompletedPoint{
+            X: &(&s + &s) * &D,
+            Z: &N_t * &constants::SQRT_AD_MINUS_ONE,
+            Y: &FieldElement::one() - &s_sq,
+            T: &FieldElement::one() + &s_sq,
+        }.to_extended())
     }
 
     /// Return a `RistrettoPoint` chosen uniformly at random using a user-provided RNG.
@@ -710,8 +686,7 @@ impl RistrettoPoint {
     /// ```
     ///
     pub fn hash_from_bytes<D>(input: &[u8]) -> RistrettoPoint
-    where
-        D: Digest<OutputSize = U64> + Default,
+        where D: Digest<OutputSize = U64> + Default
     {
         let mut hash = D::default();
         hash.update(input);
@@ -724,8 +699,7 @@ impl RistrettoPoint {
     /// to stream data into the `Digest` than to pass a single byte
     /// slice.
     pub fn from_hash<D>(hash: D) -> RistrettoPoint
-    where
-        D: Digest<OutputSize = U64> + Default,
+        where D: Digest<OutputSize = U64> + Default
     {
         // dealing with generic arrays is clumsy, until const generics land
         let output = hash.finalize();
@@ -816,11 +790,7 @@ impl<'a, 'b> Add<&'b RistrettoPoint> for &'a RistrettoPoint {
     }
 }
 
-define_add_variants!(
-    LHS = RistrettoPoint,
-    RHS = RistrettoPoint,
-    Output = RistrettoPoint
-);
+define_add_variants!(LHS = RistrettoPoint, RHS = RistrettoPoint, Output = RistrettoPoint);
 
 impl<'b> AddAssign<&'b RistrettoPoint> for RistrettoPoint {
     fn add_assign(&mut self, _rhs: &RistrettoPoint) {
@@ -838,11 +808,7 @@ impl<'a, 'b> Sub<&'b RistrettoPoint> for &'a RistrettoPoint {
     }
 }
 
-define_sub_variants!(
-    LHS = RistrettoPoint,
-    RHS = RistrettoPoint,
-    Output = RistrettoPoint
-);
+define_sub_variants!(LHS = RistrettoPoint, RHS = RistrettoPoint, Output = RistrettoPoint);
 
 impl<'b> SubAssign<&'b RistrettoPoint> for RistrettoPoint {
     fn sub_assign(&mut self, _rhs: &RistrettoPoint) {
@@ -854,11 +820,11 @@ define_sub_assign_variants!(LHS = RistrettoPoint, RHS = RistrettoPoint);
 
 impl<T> Sum<T> for RistrettoPoint
 where
-    T: Borrow<RistrettoPoint>,
+    T: Borrow<RistrettoPoint>
 {
     fn sum<I>(iter: I) -> Self
     where
-        I: Iterator<Item = T>,
+        I: Iterator<Item = T>
     {
         iter.fold(RistrettoPoint::identity(), |acc, item| acc + item.borrow())
     }
@@ -928,7 +894,9 @@ impl MultiscalarMul for RistrettoPoint {
         J::Item: Borrow<RistrettoPoint>,
     {
         let extended_points = points.into_iter().map(|P| P.borrow().0);
-        RistrettoPoint(EdwardsPoint::multiscalar_mul(scalars, extended_points))
+        RistrettoPoint(
+            EdwardsPoint::multiscalar_mul(scalars, extended_points)
+        )
     }
 }
 
@@ -942,7 +910,7 @@ impl VartimeMultiscalarMul for RistrettoPoint {
         I::Item: Borrow<Scalar>,
         J: IntoIterator<Item = Option<RistrettoPoint>>,
     {
-        let extended_points = points.into_iter().map(|opt_P| opt_P.map(|P| P.0));
+        let extended_points = points.into_iter().map(|opt_P| opt_P.map(|P| P.borrow().0));
 
         EdwardsPoint::optional_multiscalar_mul(scalars, extended_points).map(RistrettoPoint)
     }
@@ -1002,9 +970,9 @@ impl RistrettoPoint {
         A: &RistrettoPoint,
         b: &Scalar,
     ) -> RistrettoPoint {
-        RistrettoPoint(EdwardsPoint::vartime_double_scalar_mul_basepoint(
-            a, &A.0, b,
-        ))
+        RistrettoPoint(
+            EdwardsPoint::vartime_double_scalar_mul_basepoint(a, &A.0, b)
+        )
     }
 }
 
@@ -1105,11 +1073,8 @@ impl Debug for CompressedRistretto {
 impl Debug for RistrettoPoint {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         let coset = self.coset4();
-        write!(
-            f,
-            "RistrettoPoint: coset \n{:?}\n{:?}\n{:?}\n{:?}",
-            coset[0], coset[1], coset[2], coset[3]
-        )
+        write!(f, "RistrettoPoint: coset \n{:?}\n{:?}\n{:?}\n{:?}",
+               coset[0], coset[1], coset[2], coset[3])
     }
 }
 
@@ -1121,11 +1086,11 @@ impl Debug for RistrettoPoint {
 mod test {
     use rand_core::OsRng;
 
-    use super::*;
+    use scalar::Scalar;
     use constants;
     use edwards::CompressedEdwardsY;
-    use scalar::Scalar;
-    use traits::Identity;
+    use traits::{Identity};
+    use super::*;
 
     #[test]
     #[cfg(feature = "serde")]
@@ -1133,8 +1098,7 @@ mod test {
         use bincode;
 
         let encoded = bincode::serialize(&constants::RISTRETTO_BASEPOINT_POINT).unwrap();
-        let enc_compressed =
-            bincode::serialize(&constants::RISTRETTO_BASEPOINT_COMPRESSED).unwrap();
+        let enc_compressed = bincode::serialize(&constants::RISTRETTO_BASEPOINT_COMPRESSED).unwrap();
         assert_eq!(encoded, enc_compressed);
 
         // Check that the encoding is 32 bytes exactly
@@ -1165,6 +1129,7 @@ mod test {
 
     #[test]
     fn impl_sum() {
+
         // Test that sum works for non-empty iterators
         let BASE = constants::RISTRETTO_BASEPOINT_POINT;
 
@@ -1234,70 +1199,22 @@ mod test {
         // Table of encodings of i*basepoint
         // Generated using ristretto.sage
         let compressed = [
-            CompressedRistretto([
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0,
-            ]),
-            CompressedRistretto([
-                226, 242, 174, 10, 106, 188, 78, 113, 168, 132, 169, 97, 197, 0, 81, 95, 88, 227,
-                11, 106, 165, 130, 221, 141, 182, 166, 89, 69, 224, 141, 45, 118,
-            ]),
-            CompressedRistretto([
-                106, 73, 50, 16, 247, 73, 156, 209, 127, 236, 181, 16, 174, 12, 234, 35, 161, 16,
-                232, 213, 185, 1, 248, 172, 173, 211, 9, 92, 115, 163, 185, 25,
-            ]),
-            CompressedRistretto([
-                148, 116, 31, 93, 93, 82, 117, 94, 206, 79, 35, 240, 68, 238, 39, 213, 209, 234,
-                30, 43, 209, 150, 180, 98, 22, 107, 22, 21, 42, 157, 2, 89,
-            ]),
-            CompressedRistretto([
-                218, 128, 134, 39, 115, 53, 139, 70, 111, 250, 223, 224, 179, 41, 58, 179, 217,
-                253, 83, 197, 234, 108, 149, 83, 88, 245, 104, 50, 45, 175, 106, 87,
-            ]),
-            CompressedRistretto([
-                232, 130, 177, 49, 1, 107, 82, 193, 211, 51, 112, 128, 24, 124, 247, 104, 66, 62,
-                252, 203, 181, 23, 187, 73, 90, 184, 18, 196, 22, 15, 244, 78,
-            ]),
-            CompressedRistretto([
-                246, 71, 70, 211, 201, 43, 19, 5, 14, 216, 216, 2, 54, 167, 240, 0, 124, 59, 63,
-                150, 47, 91, 167, 147, 209, 154, 96, 30, 187, 29, 244, 3,
-            ]),
-            CompressedRistretto([
-                68, 245, 53, 32, 146, 110, 200, 31, 189, 90, 56, 120, 69, 190, 183, 223, 133, 169,
-                106, 36, 236, 225, 135, 56, 189, 207, 166, 167, 130, 42, 23, 109,
-            ]),
-            CompressedRistretto([
-                144, 50, 147, 216, 242, 40, 126, 190, 16, 226, 55, 77, 193, 165, 62, 11, 200, 135,
-                229, 146, 105, 159, 2, 208, 119, 213, 38, 60, 221, 85, 96, 28,
-            ]),
-            CompressedRistretto([
-                2, 98, 42, 206, 143, 115, 3, 163, 28, 175, 198, 63, 143, 196, 143, 220, 22, 225,
-                200, 200, 210, 52, 178, 240, 214, 104, 82, 130, 169, 7, 96, 49,
-            ]),
-            CompressedRistretto([
-                32, 112, 111, 215, 136, 178, 114, 10, 30, 210, 165, 218, 212, 149, 43, 1, 244, 19,
-                188, 240, 231, 86, 77, 232, 205, 200, 22, 104, 158, 45, 185, 95,
-            ]),
-            CompressedRistretto([
-                188, 232, 63, 139, 165, 221, 47, 165, 114, 134, 76, 36, 186, 24, 16, 249, 82, 43,
-                198, 0, 74, 254, 149, 135, 122, 199, 50, 65, 202, 253, 171, 66,
-            ]),
-            CompressedRistretto([
-                228, 84, 158, 225, 107, 154, 160, 48, 153, 202, 32, 140, 103, 173, 175, 202, 250,
-                76, 63, 62, 78, 83, 3, 222, 96, 38, 227, 202, 143, 248, 68, 96,
-            ]),
-            CompressedRistretto([
-                170, 82, 224, 0, 223, 46, 22, 245, 95, 177, 3, 47, 195, 59, 196, 39, 66, 218, 214,
-                189, 90, 143, 192, 190, 1, 103, 67, 108, 89, 72, 80, 31,
-            ]),
-            CompressedRistretto([
-                70, 55, 107, 128, 244, 9, 178, 157, 194, 181, 246, 240, 197, 37, 145, 153, 8, 150,
-                229, 113, 111, 65, 71, 124, 211, 0, 133, 171, 127, 16, 48, 30,
-            ]),
-            CompressedRistretto([
-                224, 196, 24, 247, 200, 217, 196, 205, 215, 57, 91, 147, 234, 18, 79, 58, 217, 144,
-                33, 187, 104, 29, 252, 51, 2, 169, 217, 154, 46, 83, 230, 78,
-            ]),
+            CompressedRistretto([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+            CompressedRistretto([226, 242, 174, 10, 106, 188, 78, 113, 168, 132, 169, 97, 197, 0, 81, 95, 88, 227, 11, 106, 165, 130, 221, 141, 182, 166, 89, 69, 224, 141, 45, 118]),
+            CompressedRistretto([106, 73, 50, 16, 247, 73, 156, 209, 127, 236, 181, 16, 174, 12, 234, 35, 161, 16, 232, 213, 185, 1, 248, 172, 173, 211, 9, 92, 115, 163, 185, 25]),
+            CompressedRistretto([148, 116, 31, 93, 93, 82, 117, 94, 206, 79, 35, 240, 68, 238, 39, 213, 209, 234, 30, 43, 209, 150, 180, 98, 22, 107, 22, 21, 42, 157, 2, 89]),
+            CompressedRistretto([218, 128, 134, 39, 115, 53, 139, 70, 111, 250, 223, 224, 179, 41, 58, 179, 217, 253, 83, 197, 234, 108, 149, 83, 88, 245, 104, 50, 45, 175, 106, 87]),
+            CompressedRistretto([232, 130, 177, 49, 1, 107, 82, 193, 211, 51, 112, 128, 24, 124, 247, 104, 66, 62, 252, 203, 181, 23, 187, 73, 90, 184, 18, 196, 22, 15, 244, 78]),
+            CompressedRistretto([246, 71, 70, 211, 201, 43, 19, 5, 14, 216, 216, 2, 54, 167, 240, 0, 124, 59, 63, 150, 47, 91, 167, 147, 209, 154, 96, 30, 187, 29, 244, 3]),
+            CompressedRistretto([68, 245, 53, 32, 146, 110, 200, 31, 189, 90, 56, 120, 69, 190, 183, 223, 133, 169, 106, 36, 236, 225, 135, 56, 189, 207, 166, 167, 130, 42, 23, 109]),
+            CompressedRistretto([144, 50, 147, 216, 242, 40, 126, 190, 16, 226, 55, 77, 193, 165, 62, 11, 200, 135, 229, 146, 105, 159, 2, 208, 119, 213, 38, 60, 221, 85, 96, 28]),
+            CompressedRistretto([2, 98, 42, 206, 143, 115, 3, 163, 28, 175, 198, 63, 143, 196, 143, 220, 22, 225, 200, 200, 210, 52, 178, 240, 214, 104, 82, 130, 169, 7, 96, 49]),
+            CompressedRistretto([32, 112, 111, 215, 136, 178, 114, 10, 30, 210, 165, 218, 212, 149, 43, 1, 244, 19, 188, 240, 231, 86, 77, 232, 205, 200, 22, 104, 158, 45, 185, 95]),
+            CompressedRistretto([188, 232, 63, 139, 165, 221, 47, 165, 114, 134, 76, 36, 186, 24, 16, 249, 82, 43, 198, 0, 74, 254, 149, 135, 122, 199, 50, 65, 202, 253, 171, 66]),
+            CompressedRistretto([228, 84, 158, 225, 107, 154, 160, 48, 153, 202, 32, 140, 103, 173, 175, 202, 250, 76, 63, 62, 78, 83, 3, 222, 96, 38, 227, 202, 143, 248, 68, 96]),
+            CompressedRistretto([170, 82, 224, 0, 223, 46, 22, 245, 95, 177, 3, 47, 195, 59, 196, 39, 66, 218, 214, 189, 90, 143, 192, 190, 1, 103, 67, 108, 89, 72, 80, 31]),
+            CompressedRistretto([70, 55, 107, 128, 244, 9, 178, 157, 194, 181, 246, 240, 197, 37, 145, 153, 8, 150, 229, 113, 111, 65, 71, 124, 211, 0, 133, 171, 127, 16, 48, 30]),
+            CompressedRistretto([224, 196, 24, 247, 200, 217, 196, 205, 215, 57, 91, 147, 234, 18, 79, 58, 217, 144, 33, 187, 104, 29, 252, 51, 2, 169, 217, 154, 46, 83, 230, 78]),
         ];
         let mut bp = RistrettoPoint::identity();
         for i in 0..16 {
@@ -1334,137 +1251,41 @@ mod test {
         // ristretto.sage does not mask the high bit of a field element.  When the high bit is set,
         // the ristretto.sage elligator implementation gives different results, since it takes a
         // different field element as input.
-        let bytes: [[u8; 32]; 16] = [
-            [
-                184, 249, 135, 49, 253, 123, 89, 113, 67, 160, 6, 239, 7, 105, 211, 41, 192, 249,
-                185, 57, 9, 102, 70, 198, 15, 127, 7, 26, 160, 102, 134, 71,
-            ],
-            [
-                229, 14, 241, 227, 75, 9, 118, 60, 128, 153, 226, 21, 183, 217, 91, 136, 98, 0,
-                231, 156, 124, 77, 82, 139, 142, 134, 164, 169, 169, 62, 250, 52,
-            ],
-            [
-                115, 109, 36, 220, 180, 223, 99, 6, 204, 169, 19, 29, 169, 68, 84, 23, 21, 109,
-                189, 149, 127, 205, 91, 102, 172, 35, 112, 35, 134, 69, 186, 34,
-            ],
-            [
-                16, 49, 96, 107, 171, 199, 164, 9, 129, 16, 64, 62, 241, 63, 132, 173, 209, 160,
-                112, 215, 105, 50, 157, 81, 253, 105, 1, 154, 229, 25, 120, 83,
-            ],
-            [
-                156, 131, 161, 162, 236, 251, 5, 187, 167, 171, 17, 178, 148, 210, 90, 207, 86, 21,
-                79, 161, 167, 215, 234, 1, 136, 242, 182, 248, 38, 85, 79, 86,
-            ],
-            [
-                251, 177, 124, 54, 18, 101, 75, 235, 245, 186, 19, 46, 133, 157, 229, 64, 10, 136,
-                181, 185, 78, 144, 254, 167, 137, 49, 107, 10, 61, 10, 21, 25,
-            ],
-            [
-                232, 193, 20, 68, 240, 77, 186, 77, 183, 40, 44, 86, 150, 31, 198, 212, 76, 81, 3,
-                217, 197, 8, 126, 128, 126, 152, 164, 208, 153, 44, 189, 77,
-            ],
-            [
-                173, 229, 149, 177, 37, 230, 30, 69, 61, 56, 172, 190, 219, 115, 167, 194, 71, 134,
-                59, 75, 28, 244, 118, 26, 162, 97, 64, 16, 15, 189, 30, 64,
-            ],
-            [
-                106, 71, 61, 107, 250, 117, 42, 151, 91, 202, 212, 100, 52, 188, 190, 21, 125, 218,
-                31, 18, 253, 241, 160, 133, 57, 242, 3, 164, 189, 68, 111, 75,
-            ],
-            [
-                112, 204, 182, 90, 220, 198, 120, 73, 173, 107, 193, 17, 227, 40, 162, 36, 150,
-                141, 235, 55, 172, 183, 12, 39, 194, 136, 43, 153, 244, 118, 91, 89,
-            ],
-            [
-                111, 24, 203, 123, 254, 189, 11, 162, 51, 196, 163, 136, 204, 143, 10, 222, 33,
-                112, 81, 205, 34, 35, 8, 66, 90, 6, 164, 58, 170, 177, 34, 25,
-            ],
-            [
-                225, 183, 30, 52, 236, 82, 6, 183, 109, 25, 227, 181, 25, 82, 41, 193, 80, 77, 161,
-                80, 242, 203, 79, 204, 136, 245, 131, 110, 237, 106, 3, 58,
-            ],
-            [
-                207, 246, 38, 56, 30, 86, 176, 90, 27, 200, 61, 42, 221, 27, 56, 210, 79, 178, 189,
-                120, 68, 193, 120, 167, 77, 185, 53, 197, 124, 128, 191, 126,
-            ],
-            [
-                1, 136, 215, 80, 240, 46, 63, 147, 16, 244, 230, 207, 82, 189, 74, 50, 106, 169,
-                138, 86, 30, 131, 214, 202, 166, 125, 251, 228, 98, 24, 36, 21,
-            ],
-            [
-                210, 207, 228, 56, 155, 116, 207, 54, 84, 195, 251, 215, 249, 199, 116, 75, 109,
-                239, 196, 251, 194, 246, 252, 228, 70, 146, 156, 35, 25, 39, 241, 4,
-            ],
-            [
-                34, 116, 123, 9, 8, 40, 93, 189, 9, 103, 57, 103, 66, 227, 3, 2, 157, 107, 134,
-                219, 202, 74, 230, 154, 78, 107, 219, 195, 214, 14, 84, 80,
-            ],
+        let bytes: [[u8;32]; 16] = [
+            [184, 249, 135, 49, 253, 123, 89, 113, 67, 160, 6, 239, 7, 105, 211, 41, 192, 249, 185, 57, 9, 102, 70, 198, 15, 127, 7, 26, 160, 102, 134, 71],
+            [229, 14, 241, 227, 75, 9, 118, 60, 128, 153, 226, 21, 183, 217, 91, 136, 98, 0, 231, 156, 124, 77, 82, 139, 142, 134, 164, 169, 169, 62, 250, 52],
+            [115, 109, 36, 220, 180, 223, 99, 6, 204, 169, 19, 29, 169, 68, 84, 23, 21, 109, 189, 149, 127, 205, 91, 102, 172, 35, 112, 35, 134, 69, 186, 34],
+            [16, 49, 96, 107, 171, 199, 164, 9, 129, 16, 64, 62, 241, 63, 132, 173, 209, 160, 112, 215, 105, 50, 157, 81, 253, 105, 1, 154, 229, 25, 120, 83],
+            [156, 131, 161, 162, 236, 251, 5, 187, 167, 171, 17, 178, 148, 210, 90, 207, 86, 21, 79, 161, 167, 215, 234, 1, 136, 242, 182, 248, 38, 85, 79, 86],
+            [251, 177, 124, 54, 18, 101, 75, 235, 245, 186, 19, 46, 133, 157, 229, 64, 10, 136, 181, 185, 78, 144, 254, 167, 137, 49, 107, 10, 61, 10, 21, 25],
+            [232, 193, 20, 68, 240, 77, 186, 77, 183, 40, 44, 86, 150, 31, 198, 212, 76, 81, 3, 217, 197, 8, 126, 128, 126, 152, 164, 208, 153, 44, 189, 77],
+            [173, 229, 149, 177, 37, 230, 30, 69, 61, 56, 172, 190, 219, 115, 167, 194, 71, 134, 59, 75, 28, 244, 118, 26, 162, 97, 64, 16, 15, 189, 30, 64],
+            [106, 71, 61, 107, 250, 117, 42, 151, 91, 202, 212, 100, 52, 188, 190, 21, 125, 218, 31, 18, 253, 241, 160, 133, 57, 242, 3, 164, 189, 68, 111, 75],
+            [112, 204, 182, 90, 220, 198, 120, 73, 173, 107, 193, 17, 227, 40, 162, 36, 150, 141, 235, 55, 172, 183, 12, 39, 194, 136, 43, 153, 244, 118, 91, 89],
+            [111, 24, 203, 123, 254, 189, 11, 162, 51, 196, 163, 136, 204, 143, 10, 222, 33, 112, 81, 205, 34, 35, 8, 66, 90, 6, 164, 58, 170, 177, 34, 25],
+            [225, 183, 30, 52, 236, 82, 6, 183, 109, 25, 227, 181, 25, 82, 41, 193, 80, 77, 161, 80, 242, 203, 79, 204, 136, 245, 131, 110, 237, 106, 3, 58],
+            [207, 246, 38, 56, 30, 86, 176, 90, 27, 200, 61, 42, 221, 27, 56, 210, 79, 178, 189, 120, 68, 193, 120, 167, 77, 185, 53, 197, 124, 128, 191, 126],
+            [1, 136, 215, 80, 240, 46, 63, 147, 16, 244, 230, 207, 82, 189, 74, 50, 106, 169, 138, 86, 30, 131, 214, 202, 166, 125, 251, 228, 98, 24, 36, 21],
+            [210, 207, 228, 56, 155, 116, 207, 54, 84, 195, 251, 215, 249, 199, 116, 75, 109, 239, 196, 251, 194, 246, 252, 228, 70, 146, 156, 35, 25, 39, 241, 4],
+            [34, 116, 123, 9, 8, 40, 93, 189, 9, 103, 57, 103, 66, 227, 3, 2, 157, 107, 134, 219, 202, 74, 230, 154, 78, 107, 219, 195, 214, 14, 84, 80],
         ];
         let encoded_images: [CompressedRistretto; 16] = [
-            CompressedRistretto([
-                176, 157, 237, 97, 66, 29, 140, 166, 168, 94, 26, 157, 212, 216, 229, 160, 195,
-                246, 232, 239, 169, 112, 63, 193, 64, 32, 152, 69, 11, 190, 246, 86,
-            ]),
-            CompressedRistretto([
-                234, 141, 77, 203, 181, 225, 250, 74, 171, 62, 15, 118, 78, 212, 150, 19, 131, 14,
-                188, 238, 194, 244, 141, 138, 166, 162, 83, 122, 228, 201, 19, 26,
-            ]),
-            CompressedRistretto([
-                232, 231, 51, 92, 5, 168, 80, 36, 173, 179, 104, 68, 186, 149, 68, 40, 140, 170,
-                27, 103, 99, 140, 21, 242, 43, 62, 250, 134, 208, 255, 61, 89,
-            ]),
-            CompressedRistretto([
-                208, 120, 140, 129, 177, 179, 237, 159, 252, 160, 28, 13, 206, 5, 211, 241, 192,
-                218, 1, 97, 130, 241, 20, 169, 119, 46, 246, 29, 79, 80, 77, 84,
-            ]),
-            CompressedRistretto([
-                202, 11, 236, 145, 58, 12, 181, 157, 209, 6, 213, 88, 75, 147, 11, 119, 191, 139,
-                47, 142, 33, 36, 153, 193, 223, 183, 178, 8, 205, 120, 248, 110,
-            ]),
-            CompressedRistretto([
-                26, 66, 231, 67, 203, 175, 116, 130, 32, 136, 62, 253, 215, 46, 5, 214, 166, 248,
-                108, 237, 216, 71, 244, 173, 72, 133, 82, 6, 143, 240, 104, 41,
-            ]),
-            CompressedRistretto([
-                40, 157, 102, 96, 201, 223, 200, 197, 150, 181, 106, 83, 103, 126, 143, 33, 145,
-                230, 78, 6, 171, 146, 210, 143, 112, 5, 245, 23, 183, 138, 18, 120,
-            ]),
-            CompressedRistretto([
-                220, 37, 27, 203, 239, 196, 176, 131, 37, 66, 188, 243, 185, 250, 113, 23, 167,
-                211, 154, 243, 168, 215, 54, 171, 159, 36, 195, 81, 13, 150, 43, 43,
-            ]),
-            CompressedRistretto([
-                232, 121, 176, 222, 183, 196, 159, 90, 238, 193, 105, 52, 101, 167, 244, 170, 121,
-                114, 196, 6, 67, 152, 80, 185, 221, 7, 83, 105, 176, 208, 224, 121,
-            ]),
-            CompressedRistretto([
-                226, 181, 183, 52, 241, 163, 61, 179, 221, 207, 220, 73, 245, 242, 25, 236, 67, 84,
-                179, 222, 167, 62, 167, 182, 32, 9, 92, 30, 165, 127, 204, 68,
-            ]),
-            CompressedRistretto([
-                226, 119, 16, 242, 200, 139, 240, 87, 11, 222, 92, 146, 156, 243, 46, 119, 65, 59,
-                1, 248, 92, 183, 50, 175, 87, 40, 206, 53, 208, 220, 148, 13,
-            ]),
-            CompressedRistretto([
-                70, 240, 79, 112, 54, 157, 228, 146, 74, 122, 216, 88, 232, 62, 158, 13, 14, 146,
-                115, 117, 176, 222, 90, 225, 244, 23, 94, 190, 150, 7, 136, 96,
-            ]),
-            CompressedRistretto([
-                22, 71, 241, 103, 45, 193, 195, 144, 183, 101, 154, 50, 39, 68, 49, 110, 51, 44,
-                62, 0, 229, 113, 72, 81, 168, 29, 73, 106, 102, 40, 132, 24,
-            ]),
-            CompressedRistretto([
-                196, 133, 107, 11, 130, 105, 74, 33, 204, 171, 133, 221, 174, 193, 241, 36, 38,
-                179, 196, 107, 219, 185, 181, 253, 228, 47, 155, 42, 231, 73, 41, 78,
-            ]),
-            CompressedRistretto([
-                58, 255, 225, 197, 115, 208, 160, 143, 39, 197, 82, 69, 143, 235, 92, 170, 74, 40,
-                57, 11, 171, 227, 26, 185, 217, 207, 90, 185, 197, 190, 35, 60,
-            ]),
-            CompressedRistretto([
-                88, 43, 92, 118, 223, 136, 105, 145, 238, 186, 115, 8, 214, 112, 153, 253, 38, 108,
-                205, 230, 157, 130, 11, 66, 101, 85, 253, 110, 110, 14, 148, 112,
-            ]),
+            CompressedRistretto([176, 157, 237, 97, 66, 29, 140, 166, 168, 94, 26, 157, 212, 216, 229, 160, 195, 246, 232, 239, 169, 112, 63, 193, 64, 32, 152, 69, 11, 190, 246, 86]),
+            CompressedRistretto([234, 141, 77, 203, 181, 225, 250, 74, 171, 62, 15, 118, 78, 212, 150, 19, 131, 14, 188, 238, 194, 244, 141, 138, 166, 162, 83, 122, 228, 201, 19, 26]),
+            CompressedRistretto([232, 231, 51, 92, 5, 168, 80, 36, 173, 179, 104, 68, 186, 149, 68, 40, 140, 170, 27, 103, 99, 140, 21, 242, 43, 62, 250, 134, 208, 255, 61, 89]),
+            CompressedRistretto([208, 120, 140, 129, 177, 179, 237, 159, 252, 160, 28, 13, 206, 5, 211, 241, 192, 218, 1, 97, 130, 241, 20, 169, 119, 46, 246, 29, 79, 80, 77, 84]),
+            CompressedRistretto([202, 11, 236, 145, 58, 12, 181, 157, 209, 6, 213, 88, 75, 147, 11, 119, 191, 139, 47, 142, 33, 36, 153, 193, 223, 183, 178, 8, 205, 120, 248, 110]),
+            CompressedRistretto([26, 66, 231, 67, 203, 175, 116, 130, 32, 136, 62, 253, 215, 46, 5, 214, 166, 248, 108, 237, 216, 71, 244, 173, 72, 133, 82, 6, 143, 240, 104, 41]),
+            CompressedRistretto([40, 157, 102, 96, 201, 223, 200, 197, 150, 181, 106, 83, 103, 126, 143, 33, 145, 230, 78, 6, 171, 146, 210, 143, 112, 5, 245, 23, 183, 138, 18, 120]),
+            CompressedRistretto([220, 37, 27, 203, 239, 196, 176, 131, 37, 66, 188, 243, 185, 250, 113, 23, 167, 211, 154, 243, 168, 215, 54, 171, 159, 36, 195, 81, 13, 150, 43, 43]),
+            CompressedRistretto([232, 121, 176, 222, 183, 196, 159, 90, 238, 193, 105, 52, 101, 167, 244, 170, 121, 114, 196, 6, 67, 152, 80, 185, 221, 7, 83, 105, 176, 208, 224, 121]),
+            CompressedRistretto([226, 181, 183, 52, 241, 163, 61, 179, 221, 207, 220, 73, 245, 242, 25, 236, 67, 84, 179, 222, 167, 62, 167, 182, 32, 9, 92, 30, 165, 127, 204, 68]),
+            CompressedRistretto([226, 119, 16, 242, 200, 139, 240, 87, 11, 222, 92, 146, 156, 243, 46, 119, 65, 59, 1, 248, 92, 183, 50, 175, 87, 40, 206, 53, 208, 220, 148, 13]),
+            CompressedRistretto([70, 240, 79, 112, 54, 157, 228, 146, 74, 122, 216, 88, 232, 62, 158, 13, 14, 146, 115, 117, 176, 222, 90, 225, 244, 23, 94, 190, 150, 7, 136, 96]),
+            CompressedRistretto([22, 71, 241, 103, 45, 193, 195, 144, 183, 101, 154, 50, 39, 68, 49, 110, 51, 44, 62, 0, 229, 113, 72, 81, 168, 29, 73, 106, 102, 40, 132, 24]),
+            CompressedRistretto([196, 133, 107, 11, 130, 105, 74, 33, 204, 171, 133, 221, 174, 193, 241, 36, 38, 179, 196, 107, 219, 185, 181, 253, 228, 47, 155, 42, 231, 73, 41, 78]),
+            CompressedRistretto([58, 255, 225, 197, 115, 208, 160, 143, 39, 197, 82, 69, 143, 235, 92, 170, 74, 40, 57, 11, 171, 227, 26, 185, 217, 207, 90, 185, 197, 190, 35, 60]),
+            CompressedRistretto([88, 43, 92, 118, 223, 136, 105, 145, 238, 186, 115, 8, 214, 112, 153, 253, 38, 108, 205, 230, 157, 130, 11, 66, 101, 85, 253, 110, 110, 14, 148, 112]),
         ];
         for i in 0..16 {
             let r_0 = FieldElement::from_bytes(&bytes[i]);
@@ -1489,9 +1310,8 @@ mod test {
     fn double_and_compress_1024_random_points() {
         let mut rng = OsRng;
 
-        let points: Vec<RistrettoPoint> = (0..1024)
-            .map(|_| RistrettoPoint::random(&mut rng))
-            .collect();
+        let points: Vec<RistrettoPoint> =
+            (0..1024).map(|_| RistrettoPoint::random(&mut rng)).collect();
 
         let compressed = RistrettoPoint::double_and_compress_batch(&points);
 


### PR DESCRIPTION
We had previously fixed errors and ran rustfmt on a few files in this fork, resulting in [this diff](https://github.com/Sunscreen-tech/curve25519-dalek-ng/compare/main...Sunscreen-tech:curve25519-dalek-ng:sunscreen). I reverted those commits and added allow pragmas instead to give [this diff](https://github.com/Sunscreen-tech/curve25519-dalek-ng/compare/main...Sunscreen-tech:curve25519-dalek-ng:samtay/reverts), so that the fork is easier to maintain