### PR TITLE
Update traits.rs

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -372,6 +372,7 @@ pub trait VartimePrecomputedMultiscalarMul: Sized {
 /// This trait is only for debugging/testing, since it should be
 /// impossible for a `curve25519-dalek` user to construct an invalid
 /// point.
+#[allow(dead_code)]
 pub(crate) trait ValidityCheck {
     /// Checks whether the point is on the curve. Not CT.
     fn is_valid(&self) -> bool;


### PR DESCRIPTION
add #[allow(dead_code)] to fix the unused wanring of trait `ValidityCheck`  
before:
<img width="411" alt="1a92725db4e515c646a5a685421bf58" src="https://github.com/Sunscreen-tech/curve25519-dalek-ng/assets/50945983/6f18e2cf-0b8f-4b03-8538-9bd6d1418595">
after:
<img width="532" alt="0615c292fff17b917af6c189ed37cb1" src="https://github.com/Sunscreen-tech/curve25519-dalek-ng/assets/50945983/ebb02c4a-6259-4c45-b3a8-99408e75466f">
